### PR TITLE
Increase currencyservice memory limits to prevent OOMKilled restarts

### DIFF
--- a/online-boutique-tf/helm-chart/values.yaml
+++ b/online-boutique-tf/helm-chart/values.yaml
@@ -81,10 +81,10 @@ currencyService:
   resources:
     requests:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 200m
-      memory: 128Mi
+      memory: 256Mi
 
 emailService:
   create: true


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)